### PR TITLE
Moving stuff out of margin_plot()

### DIFF
--- a/pauvre/marginplot.py
+++ b/pauvre/marginplot.py
@@ -368,23 +368,4 @@ def run(args):
     df = filter_fastq_length_meanqual(
         df, args.filt_minlen, args.filt_maxlen, args.filt_minqual, args.filt_maxqual)
     stats(args.fastq, read_lengths, read_mean_quals, False)
-    if args.BASENAME is None:
-        file_base = opath.splitext(opath.basename(args.fastq))[0]
-    else:
-        file_base = args.BASENAME
-    # margin_plot(
-    #     df=df.dropna(),
-    #     file_base=file_base,
-    #     fileform=args.fileform,
-    #     dpi=args.dpi,
-    #     transparent=args.TRANSPARENT,
-    #     Y_AXES=args.Y_AXES,
-    #     title=args.title,
-    #     qualbin=args.qualbin,
-    #     plot_maxqual=args.plot_maxqual,
-    #     plot_minqual=args.plot_minqual,
-    #     plot_maxlen=args.plot_maxlen,
-    #     plot_minlen=args.plot_minlen,
-    #     lengthbin=args.lengthbin
-    # )
     margin_plot(df=df.dropna(), **vars(args))


### PR DESCRIPTION
I did some minor changes to the margin_plot() function:
- I moved the parsing, creating stats and filtering of the fastq input out of the function. The function now takes `df` as an argument. The parsing, stats and filtering can just be part of `run()`
- I made margin_plot() accept `**kwargs`, and pass the `args` as a `kwargs` dictionary using `margin_plot(df=df.dropna(), **vars(args))`. I changed args to kwargs everywhere. This makes that the function can easier be reused by passing a dictionary, rather than needing an argparse object.

Another reason for this kwargs/args change is that it's now easier to set defaults, e.g. to always have the Y-axes when reusing the function.

To be honest this is the first time I use `kwargs` and `**vars(args)` but it seems to work as expected when I run the script. Maybe you want to do some tests.

Looking forward to your feedback.