### PR TITLE
adding path argument to print_images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: python
+
+os:
+  - linux
+
+python:
+  - "3.4"
+  - "3.5"
+  - "3.5-dev"
+  - "3.6"
+  - "3.6-dev"
+
+before_install:
+  - cp README.md README.rst
+
+install:
+  - pip install -e .
+
+script:
+  - bash scripts/test.sh
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ python:
   - "3.6"
   - "3.6-dev"
 
-before_install:
-  - cp README.md README.rst
-
 install:
   - pip install -e .
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include scripts/test.sh

--- a/pauvre/marginplot.py
+++ b/pauvre/marginplot.py
@@ -355,13 +355,22 @@ def margin_plot(df, **kwargs):
         {0} <= Q-score (x-axis) <= {1}
         {2} <= length  (y-axis) <= {3}""".format(
             min_plot_qual, max_plot_qual, min_plot_length, max_plot_length),
-              file=stderr)
+            file=stderr)
     # Print image(s)
     if kwargs["BASENAME"] is None:
         file_base = opath.splitext(opath.basename(kwargs["fastq"]))[0]
     else:
         file_base = kwargs["BASENAME"]
-    print_images(file_base, kwargs["fileform"], kwargs["dpi"], kwargs["TRANSPARENT"])
+    if "path" in kwargs.keys():
+        path = kwargs["path"]
+    else:
+        path = None
+    print_images(
+        base_output_name=file_base,
+        image_formats=kwargs["fileform"],
+        dpi=kwargs["dpi"],
+        path=path,
+        transparent=kwargs["TRANSPARENT"])
 
 
 def run(args):

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,14 @@
+set -ev
+
+git clone https://github.com/wdecoster/nanotest.git
+
+pauvre -h
+
+pauvre marginplot -h
+pauvre marginplot -f nanotest/reads.fastq.gz
+pauvre marginplot -f nanotest/reads.fastq.gz -t "my title" --filt_maxlen 30000
+pauvre marginplot -f nanotest/reads.fastq.gz -y --filt_minqual 7 --fileform svg
+
+pauvre stats -h
+pauvre stats -f nanotest/reads.fastq.gz
+pauvre stats -f nanotest/reads.fastq.gz -H --filt_maxqual 12

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ import os
 from setuptools import setup, find_packages
 
 version_py = os.path.join(os.path.dirname(__file__), 'pauvre', 'version.py')
-version = open(version_py).read().strip().split('=')[-1].replace('"','').strip()
+version = open(version_py).read().strip().split('=')[-1].replace('"', '').strip()
 print(version)
 
 
@@ -47,17 +47,17 @@ setup(name='pauvre',
       author='Darrin Schultz',
       author_email='dts@ucsc.edu',
       classifiers=[
-            'Development Status :: 2 - Pre-Alpha',
-            'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.5',
-            'Operating System :: POSIX :: Linux',
-            'Topic :: Scientific/Engineering :: Bio-Informatics',
-            'Intended Audience :: Science/Research'
-          ],
+          'Development Status :: 2 - Pre-Alpha',
+          'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.5',
+          'Operating System :: POSIX :: Linux',
+          'Topic :: Scientific/Engineering :: Bio-Informatics',
+          'Intended Audience :: Science/Research'
+      ],
       license='GPLv3',
       provides=['pauvre'],
-      packages=find_packages(),
+      packages=find_packages() + ['scripts'],
       install_requires=[
           "matplotlib >= 2.0.2",
           "biopython >= 1.68",
@@ -65,7 +65,7 @@ setup(name='pauvre',
           "numpy >= 1.12.1"
       ],
       entry_points={
-            'console_scripts': ['pauvre=pauvre.pauvre_main:main'],
-        },
+          'console_scripts': ['pauvre=pauvre.pauvre_main:main'],
+      },
       zip_safe=False,
       include_package_data=True)

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,8 @@ setup(name='pauvre',
           "matplotlib >= 2.0.2",
           "biopython >= 1.68",
           "pandas >= 0.20.1",
-          "numpy >= 1.12.1"
+          "numpy >= 1.12.1",
+          "scipy"
       ],
       entry_points={
           'console_scripts': ['pauvre=pauvre.pauvre_main:main'],


### PR DESCRIPTION
I added a path argument (default None) to print_images. As such it is possible to specify a directory in which the plots are created. If you want you could add that as a command line argument.

As far as I know, this does not change anything to `pauvre marginplot`, but it just allows me to set an output directory from NanoPlot.

My code editor also made a bunch of stylistic changes to pauvre/functions.py according to PEP8.