### PR TITLE
Fix NameError by correcting stats.run

### DIFF
--- a/pauvre/stats.py
+++ b/pauvre/stats.py
@@ -245,4 +245,4 @@ def run(args):
     This is a wrapper function that is accessed by pauvre_main.
     Useful since we can call stats() independently from other pauvre programs."""
     df = parse_fastq_length_meanqual(args.fastq)
-    stats(args.fastq, lengths, meanQuals, args.histogram)
+    stats(df, args.fastq, args.histogram)


### PR DESCRIPTION
```[sam@tatl nanopore]$ pauvre stats -f all.fq
Traceback (most recent call last):
  File "/usr/bin/pauvre", line 11, in <module>
    load_entry_point('pauvre==0.1.85', 'console_scripts', 'pauvre')()
  File "/usr/lib/python3.6/site-packages/pauvre-0.1.85-py3.6.egg/pauvre/pauvre_main.py", line 403, in main
    args.func(parser, args)
  File "/usr/lib/python3.6/site-packages/pauvre-0.1.85-py3.6.egg/pauvre/pauvre_main.py", line 63, in run_subtool
    submodule.run(args)
  File "/usr/lib/python3.6/site-packages/pauvre-0.1.85-py3.6.egg/pauvre/stats.py", line 248, in run
    stats(args.fastq, lengths, meanQuals, args.histogram)
NameError: name 'lengths' is not defined
```