### PR TITLE
p/redwood.py: fixed what looks like a typo

### DIFF
--- a/pauvre/redwood.py
+++ b/pauvre/redwood.py
@@ -703,7 +703,7 @@ def redwood(args):
     end = time.time()
     print(end - start)
     # Print image(s)
-    ifargs.BASENAME is None:
+    if args.BASENAME is None:
         file_base = "redwood"
     else:
         file_base = args.BASENAME


### PR DESCRIPTION
Greetings,

While having a look at the packaging work in progress on Debian side, I spotted this typo, which issued the following message during byte-compilation:
```
byte-compiling /mnt/data/emollier/debian/python-pauvre/debian/python3-pauvre/usr/lib/python3.8/dist-packages/pauvre/redwood.py to redwood.cpython-38.pyc
  File "/usr/lib/python3.8/dist-packages/pauvre/redwood.py", line 706
    ifargs.BASENAME is None:
                           ^
SyntaxError: invalid syntax
```

In hope this patch helps,
Kind Regards,
Étienne.