### PR TITLE
Support biopython 1.80

### DIFF
--- a/pauvre/browser.py
+++ b/pauvre/browser.py
@@ -49,7 +49,6 @@ import time
 
 # Biopython stuff
 from Bio import SeqIO
-import Bio.SubsMat.MatrixInfo as MI
 
 
 class PlotCommand:

--- a/pauvre/synplot.py
+++ b/pauvre/synplot.py
@@ -43,7 +43,7 @@ from itertools import product
 
 # Biopython stuff
 from Bio import SeqIO
-import Bio.SubsMat.MatrixInfo as MI
+from Bio.Align import substitution_matrices
 
 # following this tutorial to install helvetica
 # https://github.com/olgabot/sciencemeetproductivity.tumblr.com/blob/master/posts/2012/11/how-to-set-helvetica-as-the-default-sans-serif-font-in.md
@@ -171,8 +171,9 @@ def shuffle_optimize_gffs(args, GFFs):
 def black_colormap():
     zeroone = np.linspace(0, 1, 100)
     colorrange = [(0,0,0,x) for x in zeroone]
-    minblosum = min(MI.blosum62.values())
-    maxblosum = max(MI.blosum62.values())
+    blosumvals = substitution_matrices.load("BLOSUM62").values()
+    minblosum = int(min(blosumvals))
+    maxblosum = int(max(blosumvals))
     colormap = {i: colorrange[int(translate(i, minblosum, maxblosum, 0, 99))]
                 for i in range(minblosum, maxblosum + 1, 1)}
     return colormap
@@ -478,8 +479,9 @@ def synplot(args):
                 y1 = len(optGFFs) - 1 - i
                 # this needs to be increased by the bar_thickness (0.9 * track_width in this case, or 0.09)
                 y2 = len(optGFFs) - 2 - i
+                blosum = substitution_matrices.load("BLOSUM62")
                 myPatches = plot_synteny(seq1, ind1, seq2, ind2, y1, y2,
-                                         featType, MI.blosum62, cm, seqname)
+                                         featType, blosum, cm, seqname)
                 for patch in myPatches:
                     allPatches.append(patch)
 


### PR DESCRIPTION
Good day,

Starting with Biopython 1.75, Bio.Align.substitution_matrices is introduced as replacement for the unmaintained Bio.SubsMat.  Starting with Biopython 1.80, Bio.SubsMat is obsolete and removed; this breaks parts of pauvre.

This branch ports SubsMat call in pauvre/synplot.py code to support Biopython 1.80 by using Bio.Align.substitution_matrices instead of Bio.SubsMat where it is used, and removes an unused import of SubsMat in pauvre/.

This should fix/workaround pauvre Github issue #45.

Note the way this patch is done is at the expense of supporting Biopython versions lesser than 1.75, to keep things simple enough.  I'm open to further changes in case you want to keep retrocompatibility; I haven't introduced that because I wouldn't have been able to quickly test the retrocompatibility thoroughly.

In hope this helps,
Étienne.