### PR TITLE
functions.py: fix test failure with pandas 2.0

### DIFF
--- a/pauvre/functions.py
+++ b/pauvre/functions.py
@@ -72,8 +72,8 @@ class GFFParse():
         self.features = pd.read_csv(self.filename, comment='#',
                                     sep='\t', names=gffnames)
         self.features['name'] = self.features['tags'].apply(self._get_name)
-        self.features.drop('dunno1', 1, inplace=True)
-        self.features.drop('dunno2', 1, inplace=True)
+        self.features.drop('dunno1', axis=1, inplace=True)
+        self.features.drop('dunno2', axis=1, inplace=True)
         self.features.reset_index(inplace=True, drop=True)
         # warn the user if there are CDS or gene entries not divisible by three
         self._check_triplets()


### PR DESCRIPTION
As seen in [Debian bug #1044070], the module pauvre sees the below test failure:

	  File "/<<PKGBUILDDIR>>/.pybuild/cpython3_3.11_pauvre/build/pauvre/functions.py", line 75, in __init__
	    self.features.drop('dunno1', 1, inplace=True)
	TypeError: DataFrame.drop() takes from 1 to 2 positional arguments but 3 positional arguments (and 1 keyword-only argument) were given

Upon analysis, this looks to be caused by a subtle but fatal (and unfortunately undocumented) change in pandas.DataFram.drop signature. Explicitly specifying the axis= argument looks to correct the issue.

[Debian bug #1044070]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1044070