### PR TITLE
fix SyntaxWarning

### DIFF
--- a/pauvre/gfftools.py
+++ b/pauvre/gfftools.py
@@ -175,7 +175,7 @@ def _plot_left_to_right_introns_top(panel, geneid, db, y_pos, text = None):
     return panel
 
 def _plot_lff(panel, left_df, right_df, colorMap, y_pos, bar_thickness, text):
-    """ plots a lff patch
+    r""" plots a lff patch
       1__________2      ____________
       | #lff      \     \ #rff      \
       | left for   \3     \ right for \
@@ -256,7 +256,7 @@ def _plot_label(panel, df, y_pos, bar_thickness, rotate = False, arrow = False):
     return panel
 
 def _plot_rff(panel, left_df, right_df, colorMap, y_pos, bar_thickness, text):
-    """ plots a rff patch
+    r""" plots a rff patch
       ____________      1__________2
       | #lff      \     \ #rff      \
       | left for   \    6\ right for \3

--- a/pauvre/synplot.py
+++ b/pauvre/synplot.py
@@ -527,7 +527,7 @@ def synplot(args):
         #print("{} patches came out of gffplot_horizontal()".format(len(patches)))
         seq_name = gff.features['sequence'].unique()[0]
         if args.gff_labels:
-            seq_name = "$\it{{{0}}}$".format(gff.species)
+            seq_name = r"$\it{{{0}}}$".format(gff.species)
         panel0.text(0 + x_offset, len(optGFFs) - i - 1 + (0.18/2),
                     seq_name, fontsize = 12,
                     ha='left', va='bottom',


### PR DESCRIPTION
This patch converts a couple of strings to raw strings in order to fix:

	  /usr/lib/python3/dist-packages/pauvre/gfftools.py:178:
	SyntaxWarning: invalid escape sequence '\ '
	    """ plots a lff patch
	  /usr/lib/python3/dist-packages/pauvre/gfftools.py:259:
	SyntaxWarning: invalid escape sequence '\ '
	    """ plots a rff patch
	  /usr/lib/python3/dist-packages/pauvre/synplot.py:531: SyntaxWarning:
	invalid escape sequence '\i'
	    seq_name = "$\it{{{0}}}$".format(gff.species)

This was initially reported in [Debian bug #1086899].

[Debian bug #1086899]: https://bugs.debian.org/1086899